### PR TITLE
Add ability to reset selected images

### DIFF
--- a/ImagePickerSheetController/ImagePickerSheetController/ImagePickerAction.swift
+++ b/ImagePickerSheetController/ImagePickerSheetController/ImagePickerAction.swift
@@ -28,20 +28,23 @@ public class ImagePickerAction {
     /// The style of the action. This is used to call a cancel handler when dismissing the controller by tapping the background.
     public let style: ImagePickerActionStyle
     
+    /// Set to 'true' to reset the currently selected images when the action is selected.
+    public let reset: Bool
+    
     let handler: Handler
     let secondaryHandler: SecondaryHandler
     
     /// Initializes a new ImagePickerAction. The secondary title and handler are used when at least 1 image has been selected.
     /// Secondary title defaults to title if not specified.
     /// Secondary handler defaults to handler if not specified.
-    public convenience init(title: String, secondaryTitle: String? = nil, style: ImagePickerActionStyle = .Default, handler: Handler, secondaryHandler: SecondaryHandler? = nil) {
-        self.init(title: title, secondaryTitle: secondaryTitle.map { string in { _ in string }}, style: style, handler: handler, secondaryHandler: secondaryHandler)
+    public convenience init(title: String, secondaryTitle: String? = nil, style: ImagePickerActionStyle = .Default, reset: Bool = false, handler: Handler, secondaryHandler: SecondaryHandler? = nil) {
+        self.init(title: title, secondaryTitle: secondaryTitle.map { string in { _ in string }}, style: style, reset: reset, handler: handler, secondaryHandler: secondaryHandler)
     }
     
     /// Initializes a new ImagePickerAction. The secondary title and handler are used when at least 1 image has been selected.
     /// Secondary title defaults to title if not specified. Use the closure to format a title according to the selection.
     /// Secondary handler defaults to handler if not specified
-    public init(title: String, secondaryTitle: Title?, style: ImagePickerActionStyle = .Default, handler: Handler, var secondaryHandler: SecondaryHandler? = nil) {
+    public init(title: String, secondaryTitle: Title?, style: ImagePickerActionStyle = .Default, reset: Bool = false, handler: Handler, var secondaryHandler: SecondaryHandler? = nil) {
         if secondaryHandler == nil {
             secondaryHandler = { action, _ in
                 handler(action)
@@ -51,6 +54,7 @@ public class ImagePickerAction {
         self.title = title
         self.secondaryTitle = secondaryTitle ?? { _ in title }
         self.style = style
+        self.reset = reset
         self.handler = handler
         self.secondaryHandler = secondaryHandler!
     }

--- a/ImagePickerSheetController/ImagePickerSheetController/ImagePickerSheetController.swift
+++ b/ImagePickerSheetController/ImagePickerSheetController/ImagePickerSheetController.swift
@@ -22,7 +22,7 @@ public enum ImagePickerMediaType {
 public class ImagePickerSheetController: UIViewController {
     
     private lazy var sheetController: SheetController = {
-        let controller = SheetController(previewCollectionView: self.previewCollectionView)
+        let controller = SheetController(previewCollectionView: self.previewCollectionView, imagePicker: self)
         controller.actionHandlingCallback = { [weak self] in
             self?.dismissViewControllerAnimated(true, completion: nil)
         }
@@ -194,6 +194,14 @@ public class ImagePickerSheetController: UIViewController {
     }
     
     // MARK: - Images
+    
+    public func resetSelection() {
+        for index in selectedImageIndices {
+            supplementaryViews[index]?.selected = false
+        }
+        selectedImageIndices = []
+        sheetController.reloadActionItems()
+    }
     
     private func sizeForAsset(asset: PHAsset, scale: CGFloat = 1) -> CGSize {
         let proportion = CGFloat(asset.pixelWidth)/CGFloat(asset.pixelHeight)

--- a/ImagePickerSheetController/ImagePickerSheetController/Sheet/SheetController.swift
+++ b/ImagePickerSheetController/ImagePickerSheetController/Sheet/SheetController.swift
@@ -27,6 +27,7 @@ class SheetController: NSObject {
     }()
     
     var previewCollectionView: PreviewCollectionView
+    private weak var imagePicker: ImagePickerSheetController?
     
     private(set) var actions = [ImagePickerAction]()
     
@@ -49,8 +50,9 @@ class SheetController: NSObject {
     
     // MARK: - Initialization
     
-    init(previewCollectionView: PreviewCollectionView) {
+    init(previewCollectionView: PreviewCollectionView, imagePicker: ImagePickerSheetController) {
         self.previewCollectionView = previewCollectionView
+        self.imagePicker = imagePicker
         
         super.init()
     }
@@ -251,7 +253,13 @@ extension SheetController: UICollectionViewDelegate {
     func collectionView(collectionView: UICollectionView, didSelectItemAtIndexPath indexPath: NSIndexPath) {
         collectionView.deselectItemAtIndexPath(indexPath, animated: true)
         
-        handleAction(actions[indexPath.item])
+        let action = actions[indexPath.item]
+        
+        if action.reset {
+            imagePicker?.resetSelection()
+        }
+        
+        handleAction(action)
     }
     
 }


### PR DESCRIPTION
If an image is already selected when a user taps 'Take Photo', it will skip to the secondary action because the numberOfSelectedImages is already > 0, and the photo is added, rather than presenting the camera UI as expected.

Note that the example app avoids this scenario, because the 'Take Photo' action is no longer available once a photo is selected.

This PR adds the ability for an action to reset the selected images, allowing the 'Take Photo' action to work as expected.